### PR TITLE
Fix subtype errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.7
+
+updating documentaion
 ## 0.4.6
 
 fixing a bug

--- a/lib/long_task/app_client.dart
+++ b/lib/long_task/app_client.dart
@@ -44,9 +44,9 @@ class AppClient {
   }
 
   static Future<Map<String, dynamic>?> getData() async {
-    var stringData = await channel.invokeMethod(_GET_SERVICE_DATA) as String?;
+    String? stringData = await channel.invokeMethod<String?>(_GET_SERVICE_DATA);
     if (stringData == null) return null;
-    Map<String, dynamic> json = jsonDecode(stringData);
+    Map<String, dynamic>? json = jsonDecode(stringData);
     return json;
   }
 

--- a/lib/long_task/service_client.dart
+++ b/lib/long_task/service_client.dart
@@ -27,5 +27,5 @@ class ServiceClient {
     return channel.invokeMethod(_END_EXECUTION, dataWrapper.toJson());
   }
 
-  static Future<String?> stopService() => channel.invokeMethod(_STOP_SERVICE) as Future<String?>;
+  static Future<String?> stopService() => channel.invokeMethod<String?>(_STOP_SERVICE);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_long_task
 description: android long task is a flutter plugin to run dart code in an android foreground service with simplicity
-version: 0.4.6
+version: 0.4.7
 homepage: https://github.com/easazade/android-long-task
 
 environment:


### PR DESCRIPTION
Hello

Thanks for your Flutter plugin.

There are some subtype errors when running with thle latest Flutter version and Dart null safety mode enabled:
```
E/flutter (24246): [ERROR:flutter/lib/ui/ui_dart_state.cc(199)] Unhandled Exception: type 'Future<dynamic>' is not a subtype of type 'Future<String?>' in type cast
E/flutter (24246): #0      ServiceClient.stopService (package:android_long_task/long_task/service_client.dart:30)

E/flutter (18800): [ERROR:flutter/lib/ui/ui_dart_state.cc(213)] Unhandled Exception: type 'Null' is not a subtype of type 'Map<String, dynamic>'
E/flutter (18800): #0      AppClient.getData (package:android_long_task/long_task/app_client.dart:49)
```

The bug in app_client.dart is related to https://github.com/easazade/android-long-task/issues/5
I can see you fix, but I propose a better solution, which also works for service_client.dart

Thanks.